### PR TITLE
Use only handler instance per request.

### DIFF
--- a/oauth2_provider/oidc/__init__.py
+++ b/oauth2_provider/oidc/__init__.py
@@ -3,9 +3,4 @@ OpenID Connect utilities.
 
 """
 
-from oauth2_provider.oidc.core import (
-    authorized_scopes,
-    id_token_claims,
-    userinfo_claims,
-    encode_claims
-)
+from oauth2_provider.oidc.core import IDToken, id_token, userinfo


### PR DESCRIPTION
Allows optimizing handlers by maintaining state between calls to their
scope and claims methods.

Also includes documentation updates and cleanup.

AN-3680
