### PR TITLE
MA-291 Allow API access without email activation.

### DIFF
--- a/oauth2_provider/forms.py
+++ b/oauth2_provider/forms.py
@@ -80,7 +80,14 @@ class PasswordGrantForm(provider.oauth2.forms.PasswordGrantForm):
             except User.DoesNotExist:
                 user = None
 
-        if user is None or not user.is_active:
+        if (
+            user is None
+            # TODO This is a temporary workaround while the is_active field on the
+            # user is coupled with whether or not the user has verified ownership
+            # of their claimed email address.  Once is_active is decoupled from
+            # verified_email, we can uncomment the following line.
+            # or not user.is_active
+        ):
             raise OAuthValidationError({'error': 'invalid_grant'})
 
         data['user'] = user

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 django>=1.4.12
-PyJWT>=0.2.1
+PyJWT==0.2.1
 
--e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-2#egg=django-oauth2-provider
+-e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-3#egg=django-oauth2-provider

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,10 @@ setup(
     ],
     packages=['oauth2_provider'],
     dependency_links=[
-        'git+https://github.com/edx/django-oauth2-provider@0.2.7-fork-edx-2#egg=django-oauth2-provider-0.2.7-fork-edx-2',
+        'git+https://github.com/edx/django-oauth2-provider@0.2.7-fork-edx-3#egg=django-oauth2-provider-0.2.7-fork-edx-3',
     ],
     install_requires=[
-        'django-oauth2-provider==0.2.7-fork-edx-2',
+        'django-oauth2-provider==0.2.7-fork-edx-3',
         'PyJWT==0.2.1'
     ]
 )


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MA-291

This PR allows edX users to authenticate via OAuth without having their email addresses verified.  It allows users to access our OAuth-gated APIs without coupling the email-verification workflow.

These changes are included in the edx-platform via the following PR: https://github.com/edx/edx-platform/pull/7025

Please review: @wedaly @BenjiLee 