### PR TITLE
Run on travis container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
@rlucioni I'm not sure why coveralls is broken, but we should get this in also because builds will run *much* faster.