### PR TITLE
Include oauth2-provider's tests module in the installed package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='edx-oauth2-provider',
-    version='0.5.4',
+    version='0.5.5',
     description='Provide OAuth2 access to edX installations',
     author='edX',
     url='https://github.com/edx/edx-oauth2-provider',
@@ -18,7 +18,7 @@ setup(
         'Programming Language :: Python',
         'Framework :: Django',
     ],
-    packages=find_packages(exclude=['tests', '*.tests']),
+    packages=find_packages(exclude=['tests']),
     dependency_links=[
         'git+https://github.com/edx/django-oauth2-provider@0.2.7-fork-edx-5#egg=django-oauth2-provider-0.2.7-fork-edx-5',
     ],


### PR DESCRIPTION
@jzoldak, as discussed. This should resolve test failures seen on new Jenkins workers which have never had an old version of edx-oauth2-provider installed.

@maxrothman, FYI.