### PR TITLE
Idempotent Client creation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='edx-oauth2-provider',
-    version='0.5.5',
+    version='0.5.6',
     description='Provide OAuth2 access to edX installations',
     author='edX',
     url='https://github.com/edx/edx-oauth2-provider',


### PR DESCRIPTION
Allows the same Client creation command to be executed repeatedly without creating duplicate Clients.

@mulby @feanil 