### PR TITLE
Experimental: edx_session grant for access_token endpoint

### DIFF
--- a/oauth2_provider/backends.py
+++ b/oauth2_provider/backends.py
@@ -2,16 +2,16 @@
 OAuth2 provider `django-oauth2-provider` authentication backends
 
 """
+from oauth2_provider.forms import PublicPasswordGrantForm, EdxSessionGrantForm
 
-from oauth2_provider.forms import PublicPasswordGrantForm
 
-
-class PublicPasswordBackend(object):
+class PublicClientIdFormBackend(object):
     """
-    Simple client authentication wrapper backends that delegates to
-    `oauth2_provider.forms.PublicPasswordGrantForm`
-
+    Generic client authentication wrapper backend that delegates to a form
+    class which extracts a public Client instance based on the client_id
+    parameter.
     """
+    form_class = None  # override in subclasses.
 
     def authenticate(self, request=None):
         """ Returns client if correctly authenticated. Otherwise returns None """
@@ -19,10 +19,24 @@ class PublicPasswordBackend(object):
         if request is None:
             return None
 
-        form = PublicPasswordGrantForm(request.REQUEST)
+        form = self.form_class(request.REQUEST)
 
         # pylint: disable=no-member
         if form.is_valid():
             return form.cleaned_data.get('client')
 
         return None
+
+
+class PublicPasswordBackend(PublicClientIdFormBackend):
+    """
+    Provides Client extraction via client_id for the password grant.
+    """
+    form_class = PublicPasswordGrantForm
+
+
+class ExistingSessionBackend(PublicClientIdFormBackend):
+    """
+    Provides Client extraction via client_id for the edx_session grant.
+    """
+    form_class = EdxSessionGrantForm

--- a/oauth2_provider/tests/test_edx_session.py
+++ b/oauth2_provider/tests/test_edx_session.py
@@ -1,0 +1,73 @@
+import json
+
+from django.core.urlresolvers import reverse
+from django.test.utils import override_settings
+from oauth2_provider.tests.base import BaseTestCase
+from provider.constants import PUBLIC
+
+
+@override_settings(OAUTH2_ALLOW_EDX_SESSION_GRANT=True)
+class EdxSessionAccessTokenTestCase(BaseTestCase):
+
+    def setUp(self):
+        super(EdxSessionAccessTokenTestCase, self).setUp()
+        self.auth_client.client_type = PUBLIC
+        self.auth_client.save()
+        self.default_params = {
+            'grant_type': 'edx_session',
+            'scope': 'openid profile',
+            'client_id': self.auth_client.client_id,
+        }
+
+    def get_access_token_response(self, params=None):
+        """
+        DRY helper.
+        """
+        return self.client.post(
+            reverse('oauth2:access_token'),
+            data=params if params is not None else self.default_params
+        )
+
+    @override_settings(OAUTH2_ALLOW_EDX_SESSION_GRANT=False)
+    def test_authenticated_user_without_setting(self):
+        """
+        Ensure the OAUTH2_ALLOW_EDX_SESSION_GRANT setting controls whether or
+        not the edx_session grant can be used to obtain tokens.
+        """
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.get_access_token_response()
+        self.assertEqual(400, response.status_code)
+        self.assertEqual({'error': 'invalid_grant'}, json.loads(response.content))
+
+    def test_authenticated_user(self):
+        """
+        Ensure a currently-authenticated user can successfully obtain tokens.
+        """
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.get_access_token_response()
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            {'access_token', 'id_token', 'token_type', 'scope', 'expires_in'},
+            set(json.loads(response.content).keys())
+        )
+
+    def test_anonymous_user(self):
+        """
+        Ensure a user that is not authenticated cannot obtain tokens.
+        """
+        self.client.logout()
+        response = self.get_access_token_response()
+        self.assertEqual(400, response.status_code)
+        self.assertEqual({'error': 'invalid_grant'}, json.loads(response.content))
+
+    def test_invalid_client_id(self):
+        """
+        Ensure that client_id is being checked before issuing tokens.
+        """
+        self.client.login(username=self.user.username, password=self.password)
+        token_request_params = self.default_params.copy()
+        token_request_params['client_id'] = 'invalid'
+        response = self.get_access_token_response(token_request_params)
+        self.assertEqual(400, response.status_code)
+        self.assertEqual({'error': 'invalid_client'}, json.loads(response.content))
+


### PR DESCRIPTION
ECOM-2440

Allows a user with an existing LMS/Studio login session to make access_token requests using a custom 'edx_session' grant type.

This not-terribly-secure grant type is disabled by default.  To enable it (in development or other private environments), a django setting named `OAUTH2_ALLOW_EDX_SESSION_GRANT` must be set to True.

At least two deficiencies in this implementation make it unfit for production use in its present form:
1) the oauth2 client is not authenticated.
2) there is no protection against CSRF.

Those deficiencies will be addressed either in subsequent work on this PR, or in a separate PR.

What you can do with this branch, in its current form, is obtain a JWT id_token without redirecting the user's browser (e.g. from JavaScript code), as long as the user is logged in.  To do so, make the following request:

```
POST /oauth2/access_token/ HTTP/1.1
Host: my-lms-host.org
Content-Type: application/x-www-form-urlencoded
 
grant_type=edx_session&scope=openid%20Aprofile&client_id={my_oauth2_client_id}
```

Successful responses look like this. NOTE: the `id_token` is the token to use for JWT auth to the desired service, NOT the `access_token`.
```
{
    "access_token": {access_token_value},
    "id_token": (jwt_id_token_value},
    "expires_in": 2591999,
    "token_type": "Bearer",
    "scope": "profile openid"
}
```

Authenticated requests to the Programs service (for example) can subsequently be made using the id_token's value in an Authorization header.

```
GET /api/v1/programs/ HTTP/1.1
Host: my-programs-host.org
Authorization: JWT {jwt_id_token_value}
``` 

FYI @rlucioni @clintonb @AlasdairSwan @ormsbee @nasthagiri @cpennington