### PR TITLE
[INCR-22] Support testing Python 3 in edx-oauth2-provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,14 @@ language: python
 
 python:
   - 2.7
+  - 3.6
+  - 3.7
 
 env:
-  - TOXENV=django18
-  - TOXENV=django110
   - TOXENV=django111
+  - TOXENV=django20
+  - TOXENV=django21
+  - TOXENV=django22
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,16 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=quality
-  allow-failures:
+  allow_failures:
+    - python: 3.6
+    - python: 3.7
     - python: 2.7
       env: TOXENV=django20
-    - python:2.7
+    - python: 2.7
       env: TOXENV=django21
     - python: 2.7
       env: TOXENV=django22
-    - python: 3.6
-    - python: 3.7
+
 
 cache:
   - pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,15 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=quality
+  allow-failures:
+    - python: 2.7
+      env: TOXENV=django20
+    - python:2.7
+      env: TOXENV=django21
+    - python: 2.7
+      env: TOXENV=django22
+    - python: 3.6
+    - python: 3.7
 
 cache:
   - pip

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,7 @@ requirements:
 	pip install --process-dependency-links -r test_requirements.txt
 
 test: clean ## run tests in the current virtualenv
-	coverage py.test
-	coverage report
+	py.test
 
 diff_cover: test
 	diff-cover coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ quality: ## check coding style with pycodestyle and pylint
 	tox -e quality
 
 requirements:
-	pip install --process-dependency-links -r requirements.txt
-	pip install --process-dependency-links -r test_requirements.txt
+	pip install  -r requirements.txt
+	pip install  -r test_requirements.txt
 
 test: clean ## run tests in the current virtualenv
 	py.test

--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ iframe when the user logs out.
 Testing
 -------
 
-        $ ./manage.py test
+* create a virtual environment
+* make requirements
+* make test  # currently succeeds with warnings on python 2.7
+* make test-all  # run tox tests, currently fails
 
 
 How to Contribute

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,7 +6,6 @@ factory_boy==2.8.1
 isort==4.2.5
 mock==2.0.0
 packaging>=16.8
-pluggy>=0.7
 pycodestyle==2.0.0
 pylint-django==0.7.2
 pylint==1.5.4
@@ -14,4 +13,5 @@ pytest-catchlog==1.2.2
 pytest-cov==2.7.1
 pytest-django==3.4.6
 tox-battery==0.2
-tox==2.3.1
+tox==3.9.0
+setuptools>=30.0.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 caniusepython3==7.1.0
-coverage==4.3.4
+coverage>=4.4
 ddt==1.1.1
 edx-lint==0.5.1
 factory_boy==2.8.1
@@ -11,7 +11,7 @@ pycodestyle==2.0.0
 pylint-django==0.7.2
 pylint==1.5.4
 pytest-catchlog==1.2.2
-pytest-cov==2.3.1
+pytest-cov==2.7.1
 pytest-django==3.4.6
 tox-battery==0.2
 tox==2.3.1

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-caniusepython3==4.0.0
+caniusepython3==7.1.0
 coverage==4.3.4
 ddt==1.1.1
 edx-lint==0.5.1
@@ -6,11 +6,12 @@ factory_boy==2.8.1
 isort==4.2.5
 mock==2.0.0
 packaging>=16.8
+pluggy>=0.7
 pycodestyle==2.0.0
 pylint-django==0.7.2
 pylint==1.5.4
 pytest-catchlog==1.2.2
 pytest-cov==2.3.1
-pytest-django==3.0.0
+pytest-django==3.4.6
 tox-battery==0.2
 tox==2.3.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37}-django{111,20,21,22}
+envlist = py{27,36,37}-django{111,20,21,22}
 
 [pep8]
 exclude = .git,.tox,migrations
@@ -15,7 +15,7 @@ deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
-    django22: Django>=2.2
+    django22: Django>=2.2,<2.3
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test_requirements.txt
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ whitelist_externals =
     rm
     touch
 deps =
-    Django>=1.11,<2.0
+    Django>=1.11,<2.2
     edx-django-oauth2-provider>=1.2.1,<2.0.0
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test_requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django{18,110,111}
+envlist = py{36,37}-django{111,20,21,22}
 
 [pep8]
 exclude = .git,.tox,migrations
@@ -12,9 +12,10 @@ norecursedirs = .*
 
 [testenv]
 deps =
-    django18: Django>=1.8,<1.9
-    django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
+    django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
+    django22: Django>=2.2
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test_requirements.txt
 commands =


### PR DESCRIPTION
[JIRA link](https://openedx.atlassian.net/browse/INCR-22)

Changes:
- update tox.ini per changes by bbearce on his previous attempt at this work (https://github.com/edx/edx-oauth2-provider/pull/56)
- modify target `test` in Makefile, which was attempting to run coverage as well as tests
- bump some versions in test_requirements.txt to allow `make test` and `make coverage` to run
- add some notes in README.txt

Note: `make test-all` runs with failures, as expected. 